### PR TITLE
Add toggling for pupillary photo

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -32,6 +32,11 @@ canvas {
   margin-top: 0.5rem;
 }
 
+#recipe-preview {
+  max-width: 100px;
+  margin-top: 0.5rem;
+}
+
 #dp-canvas.reduced {
   width: 100%;
   max-width: 300px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -63,6 +63,23 @@ canvas {
   cursor: crosshair;
 }
 
+#signature-controls {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.icon-btn:focus {
+  outline: none;
+}
+
 #history-list li {
   margin-bottom: 0.5rem;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -32,6 +32,18 @@ canvas {
   margin-top: 0.5rem;
 }
 
+#dp-canvas.reduced {
+  width: 100%;
+  max-width: 300px;
+  height: auto;
+  cursor: pointer;
+}
+
+.help-text {
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+
 #history-list li {
   display: flex;
   align-items: center;

--- a/js/app.js
+++ b/js/app.js
@@ -20,16 +20,38 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const signatureCanvas = document.getElementById('signature-canvas');
   const signatureCtx = signatureCanvas.getContext('2d');
+  const openSignBtn = document.getElementById('open-signature');
+  const clearSignBtn = document.getElementById('clear-signature');
+  const closeSignBtn = document.getElementById('close-signature');
+  let signatureOpen = false;
   let drawing = false;
 
+  function openSignature() {
+    signatureCanvas.classList.remove('hidden');
+    openSignBtn.style.display = 'none';
+    clearSignBtn.style.display = 'inline-block';
+    closeSignBtn.style.display = 'inline-block';
+    signatureOpen = true;
+  }
+
+  function closeSignature() {
+    signatureCanvas.classList.add('hidden');
+    openSignBtn.style.display = 'inline-block';
+    clearSignBtn.style.display = 'none';
+    closeSignBtn.style.display = 'none';
+    signatureOpen = false;
+    drawing = false;
+  }
+
   function startDraw(x, y) {
+    if (!signatureOpen) return;
     drawing = true;
     signatureCtx.beginPath();
     signatureCtx.moveTo(x, y);
   }
 
   function draw(x, y) {
-    if (!drawing) return;
+    if (!drawing || !signatureOpen) return;
     signatureCtx.lineTo(x, y);
     signatureCtx.stroke();
   }
@@ -55,6 +77,14 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
   });
   signatureCanvas.addEventListener('touchend', stopDraw);
+
+  openSignBtn.addEventListener('click', openSignature);
+  closeSignBtn.addEventListener('click', closeSignature);
+  clearSignBtn.addEventListener('click', () => {
+    signatureCtx.clearRect(0, 0, signatureCanvas.width, signatureCanvas.height);
+  });
+
+  closeSignature();
 
   const dpCanvas = document.getElementById('dp-canvas');
   const dpCtx = dpCanvas.getContext('2d');
@@ -261,8 +291,10 @@ document.addEventListener('DOMContentLoaded', () => {
         signatureCtx.drawImage(img, 0, 0);
       };
       img.src = v.signature;
+      openSignature();
     } else {
       signatureCtx.clearRect(0, 0, signatureCanvas.width, signatureCanvas.height);
+      closeSignature();
     }
   });
 
@@ -290,6 +322,7 @@ document.addEventListener('DOMContentLoaded', () => {
         saveVisit(visit);
         updateButtons();
         signatureCtx.clearRect(0, 0, signatureCanvas.width, signatureCanvas.height);
+        closeSignature();
         if (dpImage) {
           dpCtx.drawImage(dpImage, 0, 0);
         } else {
@@ -360,6 +393,7 @@ document.addEventListener('DOMContentLoaded', () => {
       catalogDiv.innerHTML = '';
       dpCtx.clearRect(0, 0, dpCanvas.width, dpCanvas.height);
       signatureCtx.clearRect(0, 0, signatureCanvas.width, signatureCanvas.height);
+      closeSignature();
       dpImage = null;
       dpPhotoSrc = null;
       dpPoints = [];

--- a/js/app.js
+++ b/js/app.js
@@ -61,6 +61,20 @@ document.addEventListener('DOMContentLoaded', () => {
   let dpPoints = [];
   let dpImage = null;
 
+  function reduceDpCanvas() {
+    dpCanvas.style.width = '100%';
+    dpCanvas.style.height = 'auto';
+    dpCanvas.classList.add('reduced');
+  }
+
+  function restoreDpCanvas() {
+    if (dpCanvas.dataset.originalWidth) {
+      dpCanvas.style.width = dpCanvas.dataset.originalWidth + 'px';
+      dpCanvas.style.height = dpCanvas.dataset.originalHeight + 'px';
+    }
+    dpCanvas.classList.remove('reduced');
+  }
+
   dpUpload.addEventListener('change', () => {
     const file = dpUpload.files[0];
     if (!file) return;
@@ -70,6 +84,9 @@ document.addEventListener('DOMContentLoaded', () => {
       dpImage.onload = () => {
         dpCanvas.width = dpImage.width;
         dpCanvas.height = dpImage.height;
+        dpCanvas.dataset.originalWidth = dpImage.width;
+        dpCanvas.dataset.originalHeight = dpImage.height;
+        restoreDpCanvas();
         dpCtx.drawImage(dpImage, 0, 0);
         dpPoints = [];
         dpResult.textContent = '0';
@@ -80,6 +97,10 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   dpCanvas.addEventListener('click', e => {
+    if (dpCanvas.classList.contains('reduced')) {
+      restoreDpCanvas();
+      return;
+    }
     if (!dpImage) return;
     const rect = dpCanvas.getBoundingClientRect();
     const x = e.clientX - rect.left;
@@ -99,6 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const distPx = Math.hypot(dx, dy);
       const distMm = (distPx * 0.264583).toFixed(1);
       dpResult.textContent = distMm;
+      reduceDpCanvas();
     }
   });
 

--- a/js/app.js
+++ b/js/app.js
@@ -13,7 +13,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const importFile = document.getElementById('import-file');
   const clearBtn = document.getElementById('clear-data');
   const exportJsonBtn = document.getElementById('export-json');
-  const exportCsvBtn = document.getElementById('export-csv');
   const exportPdfBtn = document.getElementById('export-pdf');
 
   const { jsPDF } = window.jspdf || {};
@@ -236,7 +235,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const visits = JSON.parse(localStorage.getItem('visits') || '[]');
     const hasData = visits.length > 0;
     exportJsonBtn.disabled = !hasData;
-    exportCsvBtn.disabled = !hasData;
     exportPdfBtn.disabled = !hasData;
     clearBtn.disabled = !hasData;
   }
@@ -355,11 +353,6 @@ document.addEventListener('DOMContentLoaded', () => {
     download('visitas.json', visits);
   });
 
-  document.getElementById('export-csv').addEventListener('click', () => {
-    const visits = JSON.parse(localStorage.getItem('visits') || '[]');
-    const csv = visits.map(v => `${v.timestamp};${v.clientName};${v.clientAddress}`).join('\n');
-    download('visitas.csv', csv);
-  });
 
   importBtn.addEventListener('click', () => importFile.click());
 
@@ -407,22 +400,30 @@ document.addEventListener('DOMContentLoaded', () => {
       const visits = JSON.parse(localStorage.getItem('visits') || '[]');
       const doc = new jsPDF();
       visits.forEach((v, idx) => {
-        doc.setFontSize(16);
-        doc.text(`Visita ${idx + 1}`, 10, 15);
+        doc.setFontSize(18);
+        doc.text('Relatório de Visita', 105, 15, { align: 'center' });
         doc.setFontSize(12);
         let y = 30;
-        doc.text(`Nome: ${v.clientName}`, 10, y); y += 10;
-        doc.text(`Endereço: ${v.clientAddress}`, 10, y); y += 10;
-        doc.text(`Telefone: ${v.clientPhone}`, 10, y); y += 10;
-        doc.text(`Email: ${v.clientEmail}`, 10, y); y += 10;
-        doc.text(`Data/Hora: ${v.timestamp}`, 10, y); y += 10;
-        doc.text(`Dioptria: ${v.diopters}`, 10, y); y += 10;
+        doc.text(`Nome: ${v.clientName}`, 10, y); y += 7;
+        doc.text(`Endereço: ${v.clientAddress}`, 10, y); y += 7;
+        doc.text(`Telefone: ${v.clientPhone}`, 10, y); y += 7;
+        doc.text(`Email: ${v.clientEmail}`, 10, y); y += 7;
+        doc.text(`Data/Hora: ${v.timestamp}`, 10, y); y += 7;
+        if (v.latitude && v.longitude) {
+          doc.text(`Localização: ${v.latitude.toFixed(5)}, ${v.longitude.toFixed(5)}`, 10, y); y += 7;
+        }
+        doc.text(`Dioptria: ${v.diopters}`, 10, y); y += 7;
         if (v.pupilDistance) {
-          doc.text(`DP: ${v.pupilDistance} mm`, 10, y); y += 10;
+          doc.text(`Distância Pupilar: ${v.pupilDistance} mm`, 10, y); y += 7;
         }
         if (v.recipeImage) {
-          doc.addImage(v.recipeImage, 'JPEG', 10, y, 50, 50);
-          y += 55;
+          doc.text('Receita:', 10, y); y += 5;
+          doc.addImage(v.recipeImage, 'JPEG', 10, y, 80, 80);
+          y += 85;
+        }
+        if (v.dpPhoto) {
+          doc.text('Foto DP:', 110, 30);
+          doc.addImage(v.dpPhoto, 'JPEG', 110, 35, 80, 60);
         }
         if (v.signature) {
           doc.text('Assinatura:', 10, y); y += 5;

--- a/js/app.js
+++ b/js/app.js
@@ -399,6 +399,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('export-pdf').addEventListener('click', () => {
       const visits = JSON.parse(localStorage.getItem('visits') || '[]');
       const doc = new jsPDF();
+      const generated = new Date().toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' });
       visits.forEach((v, idx) => {
         doc.setFontSize(18);
         doc.text('Relatório de Visita', 105, 15, { align: 'center' });
@@ -418,17 +419,19 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (v.recipeImage) {
           doc.text('Receita:', 10, y); y += 5;
-          doc.addImage(v.recipeImage, 'JPEG', 10, y, 80, 80);
-          y += 85;
+          doc.addImage(v.recipeImage, 'JPEG', 10, y, 70, 70);
+          y += 75;
         }
         if (v.dpPhoto) {
           doc.text('Foto DP:', 110, 30);
-          doc.addImage(v.dpPhoto, 'JPEG', 110, 35, 80, 60);
+          doc.addImage(v.dpPhoto, 'JPEG', 110, 35, 60, 45);
         }
         if (v.signature) {
           doc.text('Assinatura:', 10, y); y += 5;
-          doc.addImage(v.signature, 'PNG', 10, y, 80, 40); y += 45;
+          doc.addImage(v.signature, 'PNG', 10, y, 60, 30); y += 35;
         }
+        doc.setFontSize(10);
+        doc.text(`Gerado por SanOptics em ${generated}`, 105, 285, { align: 'center' });
         if (idx < visits.length - 1) doc.addPage();
       });
       doc.save('visitas.pdf');

--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,7 @@
           <label>Distância Pupilar</label>
           <input type="file" id="dp-upload" accept="image/*" capture="environment">
           <canvas id="dp-canvas" width="300" height="100"></canvas>
+          <p class="help-text">A imagem será reduzida após a marcação. Toque nela para alternar entre tamanho reduzido e original.</p>
           <p>DP: <span id="dp-result">0</span> mm</p>
         </fieldset>
         <fieldset>

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
         </fieldset>
         <fieldset>
           <legend>Receita Ótica</legend>
-          <input type="file" id="recipe-upload" name="recipe-upload" accept="image/*" capture="environment">
+          <input type="file" id="recipe-upload" name="recipe-upload" accept="image/*">
           <img id="recipe-preview" class="preview-image" style="display:none" />
         </fieldset>
         <fieldset>
@@ -34,7 +34,7 @@
           <label>Miopia/hipermetropia/astigmatismo OD/OE</label>
           <input type="text" id="diopters" name="diopters">
           <label>Distância Pupilar</label>
-          <input type="file" id="dp-upload" accept="image/*" capture="environment">
+          <input type="file" id="dp-upload" accept="image/*">
           <canvas id="dp-canvas" width="300" height="100"></canvas>
           <p class="help-text">A imagem será reduzida após a marcação. Toque nela para alternar entre tamanho reduzido e original.</p>
           <p>DP: <span id="dp-result">0</span> mm</p>
@@ -66,10 +66,9 @@
 
     <section id="history-section">
       <h2>Histórico de Visitas</h2>
-      <button id="export-json" disabled>Exportar JSON</button>
-      <button id="export-csv" disabled>Exportar CSV</button>
+      <button id="export-json" disabled>Exportar</button>
       <button id="export-pdf" disabled>Exportar PDF</button>
-      <button id="import-json">Importar JSON</button>
+      <button id="import-json">Importar</button>
       <input id="import-file" type="file" accept="application/json" style="display:none">
       <button id="clear-data" disabled>Limpar Dados</button>
       <ul id="history-list"></ul>

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,7 @@
         <fieldset>
           <legend>Receita Ótica</legend>
           <input type="file" id="recipe-upload" name="recipe-upload" accept="image/*" capture="environment">
+          <img id="recipe-preview" class="preview-image" style="display:none" />
         </fieldset>
         <fieldset>
           <legend>Medições</legend>

--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,12 @@
         </fieldset>
         <fieldset>
           <legend>Assinatura</legend>
-          <canvas id="signature-canvas" width="300" height="100"></canvas>
+          <div id="signature-controls">
+            <button type="button" id="open-signature" class="icon-btn" aria-label="Abrir assinatura">✏️</button>
+            <button type="button" id="clear-signature" class="icon-btn" aria-label="Limpar assinatura" style="display:none">🗑️</button>
+            <button type="button" id="close-signature" class="icon-btn" aria-label="Fechar assinatura" style="display:none">✅</button>
+          </div>
+          <canvas id="signature-canvas" width="300" height="100" class="hidden"></canvas>
         </fieldset>
         <button type="submit">Salvar Visita</button>
       </form>


### PR DESCRIPTION
## Summary
- explain in the interface how to reduce or expand the pupillary distance photo
- add CSS classes for reduced canvas and helper text
- allow the DP canvas to toggle between original and reduced sizes after marking

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859a94bcf64832982286fb41e902494