### PR TITLE
Improve file inputs and preview

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -37,6 +37,19 @@ canvas {
   margin-top: 0.5rem;
 }
 
+.preview-image.zoomed {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 90vw;
+  max-height: 90vh;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.9);
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+
 #dp-canvas.reduced {
   width: 100%;
   max-width: 300px;
@@ -89,6 +102,21 @@ canvas {
   height: 40px;
   border-radius: 4px;
   border: 1px solid #333;
+}
+
+.file-input {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.file-input input[type="file"] {
+  display: none;
+}
+
+.file-name {
+  font-size: 0.9rem;
+  color: #555;
 }
 @media (min-width: 600px) {
   form {

--- a/js/app.js
+++ b/js/app.js
@@ -5,8 +5,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const catalogSection = document.getElementById('catalog-section');
   const catalogUpload = document.getElementById('catalog-upload');
   const catalogDiv = document.getElementById('catalog');
+  const catalogFilename = document.getElementById('catalog-filename');
   const recipeUpload = document.getElementById('recipe-upload');
   const recipePreview = document.getElementById('recipe-preview');
+  const recipeFilename = document.getElementById('recipe-filename');
   const historySection = document.getElementById('history-section');
   const historyList = document.getElementById('history-list');
   const importBtn = document.getElementById('import-json');
@@ -16,6 +18,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const exportPdfBtn = document.getElementById('export-pdf');
 
   const { jsPDF } = window.jspdf || {};
+
+  function resetFileNames() {
+    recipeFilename.textContent = 'Nenhum';
+    dpFilename.textContent = 'Nenhum';
+    catalogFilename.textContent = 'Nenhum';
+  }
 
   const signatureCanvas = document.getElementById('signature-canvas');
   const signatureCtx = signatureCanvas.getContext('2d');
@@ -88,6 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const dpCanvas = document.getElementById('dp-canvas');
   const dpCtx = dpCanvas.getContext('2d');
   const dpUpload = document.getElementById('dp-upload');
+  const dpFilename = document.getElementById('dp-filename');
   const dpResult = document.getElementById('dp-result');
   let dpPoints = [];
   let dpImage = null;
@@ -95,6 +104,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   recipeUpload.addEventListener('change', () => {
     const file = recipeUpload.files[0];
+    recipeFilename.textContent = file ? file.name : 'Nenhum';
     if (!file) {
       recipePreview.src = '';
       recipePreview.style.display = 'none';
@@ -106,6 +116,11 @@ document.addEventListener('DOMContentLoaded', () => {
       recipePreview.style.display = 'block';
     };
     reader.readAsDataURL(file);
+  });
+
+  recipePreview.addEventListener('click', () => {
+    if (recipePreview.style.display === 'none') return;
+    recipePreview.classList.toggle('zoomed');
   });
 
   function reduceDpCanvas() {
@@ -124,6 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   dpUpload.addEventListener('change', () => {
     const file = dpUpload.files[0];
+    dpFilename.textContent = file ? file.name : 'Nenhum';
     if (!file) return;
     const reader = new FileReader();
     reader.onload = e => {
@@ -209,6 +225,7 @@ document.addEventListener('DOMContentLoaded', () => {
     visitForm.reset();
     recipePreview.src = '';
     recipePreview.style.display = 'none';
+    resetFileNames();
     dpCtx.clearRect(0, 0, dpCanvas.width, dpCanvas.height);
     dpImage = null;
     dpPhotoSrc = null;
@@ -244,6 +261,7 @@ document.addEventListener('DOMContentLoaded', () => {
   historySection.classList.remove('hidden');
   loadHistory();
   updateButtons();
+  resetFileNames();
 
   historyList.addEventListener('click', e => {
     const li = e.target.closest('li');
@@ -260,9 +278,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (v.recipeImage) {
       recipePreview.src = v.recipeImage;
       recipePreview.style.display = 'block';
+      recipeFilename.textContent = 'carregado';
     } else {
       recipePreview.src = '';
       recipePreview.style.display = 'none';
+      recipeFilename.textContent = 'Nenhum';
     }
     if (v.dpPhoto) {
       dpImage = new Image();
@@ -276,10 +296,12 @@ document.addEventListener('DOMContentLoaded', () => {
       };
       dpImage.src = v.dpPhoto;
       dpPhotoSrc = v.dpPhoto;
+      dpFilename.textContent = 'carregado';
     } else {
       dpCtx.clearRect(0, 0, dpCanvas.width, dpCanvas.height);
       dpImage = null;
       dpPhotoSrc = null;
+      dpFilename.textContent = 'Nenhum';
     }
     dpResult.textContent = v.pupilDistance ? v.pupilDistance : '0';
     if (v.signature) {
@@ -384,6 +406,7 @@ document.addEventListener('DOMContentLoaded', () => {
       recipePreview.src = '';
       recipePreview.style.display = 'none';
       catalogDiv.innerHTML = '';
+      resetFileNames();
       dpCtx.clearRect(0, 0, dpCanvas.width, dpCanvas.height);
       signatureCtx.clearRect(0, 0, signatureCanvas.width, signatureCanvas.height);
       closeSignature();
@@ -450,6 +473,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   catalogUpload.addEventListener('change', () => {
     const files = Array.from(catalogUpload.files);
+    catalogFilename.textContent = files.length ? `${files.length} arquivo(s)` : 'Nenhum';
     files.forEach(file => {
       const reader = new FileReader();
       reader.onload = e => {

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,11 @@
         </fieldset>
         <fieldset>
           <legend>Receita Ótica</legend>
-          <input type="file" id="recipe-upload" name="recipe-upload" accept="image/*">
+          <div class="file-input">
+            <label for="recipe-upload" class="icon-btn" aria-label="Adicionar foto">📷</label>
+            <span id="recipe-filename" class="file-name">Nenhum</span>
+            <input type="file" id="recipe-upload" name="recipe-upload" accept="image/*" capture="environment">
+          </div>
           <img id="recipe-preview" class="preview-image" style="display:none" />
         </fieldset>
         <fieldset>
@@ -34,7 +38,11 @@
           <label>Miopia/hipermetropia/astigmatismo OD/OE</label>
           <input type="text" id="diopters" name="diopters">
           <label>Distância Pupilar</label>
-          <input type="file" id="dp-upload" accept="image/*">
+          <div class="file-input">
+            <label for="dp-upload" class="icon-btn" aria-label="Adicionar foto">📷</label>
+            <span id="dp-filename" class="file-name">Nenhum</span>
+            <input type="file" id="dp-upload" accept="image/*" capture="environment">
+          </div>
           <canvas id="dp-canvas" width="300" height="100"></canvas>
           <p class="help-text">A imagem será reduzida após a marcação. Toque nela para alternar entre tamanho reduzido e original.</p>
           <p>DP: <span id="dp-result">0</span> mm</p>
@@ -54,7 +62,11 @@
 
     <section id="catalog-section">
       <h2>Catálogo</h2>
-      <input type="file" id="catalog-upload" accept="image/*" multiple>
+      <div class="file-input">
+        <label for="catalog-upload" class="icon-btn" aria-label="Adicionar fotos">🖼️</label>
+        <span id="catalog-filename" class="file-name">Nenhum</span>
+        <input type="file" id="catalog-upload" accept="image/*" multiple capture="environment">
+      </div>
       <div id="catalog"></div>
       <div id="budget">
         <h3>Orçamento</h3>


### PR DESCRIPTION
## Summary
- add custom file inputs with icons and camera capture
- shorten messages for empty selection
- allow zooming prescription image on click

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859c2295df88329ae0640a005052d2d