### PR TITLE
Add WhatsApp sharing via Web Share API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Depois acesse `http://localhost:8000` no navegador.
 
 Não há tela de login: ao abrir o site é possível cadastrar visitas imediatamente. Os dados ficam salvos no `localStorage` do navegador.
 Use os botões disponíveis para exportar ou importar um arquivo JSON, gerar um PDF profissional (uma visita por página) ou limpar todo o histórico. Ao exportar, os nomes dos arquivos incluem a data e hora atuais no formato `Visitas_DD-MM-YYYY_HH:MM:SS.pdf` ou `Exportado_DD-MM-YYYY_HH:MM:SS.json`.
+Também é possível compartilhar esses arquivos diretamente com outros aplicativos, como o WhatsApp, por meio do botão **Compartilhar**, disponível na seção de histórico (requer suporte ao Web Share API no navegador).
 A área de assinatura permanece visível o tempo todo. Utilize o ícone de lápis para habilitar a edição, o de lixeira para limpar e o de check para concluir. A assinatura é incluída no PDF gerado.
 O título "Histórico de Visitas" exibe, entre parênteses, a quantidade de registros salvos.
 

--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,9 @@
     <section id="history-section">
       <h2 id="history-title">Histórico de Visitas (<span id="visit-count">0</span>)</h2>
       <button id="export-json" disabled>Exportar</button>
+      <button id="share-json" disabled>Compartilhar JSON</button>
       <button id="export-pdf" disabled>Exportar PDF</button>
+      <button id="share-pdf" disabled>Compartilhar PDF</button>
       <button id="import-json">Importar</button>
       <input id="import-file" type="file" accept="application/json" style="display:none">
       <button id="clear-data" disabled>Limpar Dados</button>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -16,6 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const clearBtn = document.getElementById('clear-data');
   const exportJsonBtn = document.getElementById('export-json');
   const exportPdfBtn = document.getElementById('export-pdf');
+  const shareJsonBtn = document.getElementById('share-json');
+  const sharePdfBtn = document.getElementById('share-pdf');
   const savingOverlay = document.getElementById('saving-overlay');
   const visitCount = document.getElementById('visit-count');
 
@@ -289,6 +291,26 @@ document.addEventListener('DOMContentLoaded', () => {
     link.click();
   }
 
+  function downloadBlob(filename, blob) {
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+  }
+
+  async function shareFile(filename, blob) {
+    const file = new File([blob], filename, { type: blob.type });
+    if (navigator.canShare && navigator.canShare({ files: [file] })) {
+      try {
+        await navigator.share({ files: [file], title: filename });
+        return;
+      } catch (err) {
+        console.error('Erro ao compartilhar', err);
+      }
+    }
+    downloadBlob(filename, blob);
+  }
+
   function updateVisitCount() {
     const visits = JSON.parse(localStorage.getItem('visits') || '[]');
     if (visitCount) {
@@ -300,7 +322,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const visits = JSON.parse(localStorage.getItem('visits') || '[]');
     const hasData = visits.length > 0;
     exportJsonBtn.disabled = !hasData;
+    shareJsonBtn.disabled = !hasData;
     exportPdfBtn.disabled = !hasData;
+    sharePdfBtn.disabled = !hasData;
     clearBtn.disabled = !hasData;
     updateVisitCount();
   }
@@ -431,6 +455,15 @@ document.addEventListener('DOMContentLoaded', () => {
     download(`Exportado_${ts}.json`, visits);
   });
 
+  if (shareJsonBtn) {
+    shareJsonBtn.addEventListener('click', () => {
+      const visits = localStorage.getItem('visits') || '[]';
+      const ts = getBrTimestamp();
+      const blob = new Blob([visits], { type: 'application/json' });
+      shareFile(`Exportado_${ts}.json`, blob);
+    });
+  }
+
 
   importBtn.addEventListener('click', () => importFile.click());
 
@@ -519,6 +552,54 @@ document.addEventListener('DOMContentLoaded', () => {
       const ts = getBrTimestamp();
       doc.save(`Visitas_${ts}.pdf`);
     });
+
+    if (sharePdfBtn) {
+      sharePdfBtn.addEventListener('click', () => {
+        const visits = JSON.parse(localStorage.getItem('visits') || '[]');
+        const doc = new jsPDF();
+        const generated = new Date().toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' });
+        visits.forEach((v, idx) => {
+          doc.setFontSize(18);
+          doc.text('Relatório de Visita', 105, 15, { align: 'center' });
+          doc.setFontSize(12);
+          let y = 30;
+          doc.text(`Nome: ${v.clientName}`, 10, y); y += 7;
+          doc.text(`Endereço: ${v.clientAddress}`, 10, y); y += 7;
+          doc.text(`Telefone: ${v.clientPhone}`, 10, y); y += 7;
+          doc.text(`Email: ${v.clientEmail}`, 10, y); y += 7;
+          doc.text(`Data/Hora: ${v.timestamp}`, 10, y); y += 7;
+          if (v.latitude && v.longitude) {
+            doc.text(`Localização: ${v.latitude.toFixed(5)}, ${v.longitude.toFixed(5)}`, 10, y); y += 7;
+          }
+          doc.text(`Dioptria: ${v.diopters}`, 10, y); y += 7;
+          if (v.pupilDistance) {
+            doc.text(`Distância Pupilar: ${v.pupilDistance} mm`, 10, y); y += 7;
+          }
+          if (v.recipeImage) {
+            doc.text('Receita:', 10, y); y += 5;
+            doc.addImage(v.recipeImage, 'JPEG', 10, y, 70, 70);
+            y += 75;
+          }
+          if (Array.isArray(v.catalogImages) && v.catalogImages.length) {
+            doc.text('Catálogo:', 10, y); y += 5;
+            v.catalogImages.forEach(imgUrl => {
+              doc.addImage(imgUrl, 'JPEG', 10, y, 60, 60);
+              y += 65;
+            });
+          }
+          if (v.signature) {
+            doc.text('Assinatura:', 10, y); y += 5;
+            doc.addImage(v.signature, 'PNG', 10, y, 60, 30); y += 35;
+          }
+          doc.setFontSize(10);
+          doc.text(`Gerado por SanOptics em ${generated}`, 105, 285, { align: 'center' });
+          if (idx < visits.length - 1) doc.addPage();
+        });
+        const ts = getBrTimestamp();
+        const pdfBlob = doc.output('blob');
+        shareFile(`Visitas_${ts}.pdf`, pdfBlob);
+      });
+    }
 
   }
 


### PR DESCRIPTION
## Summary
- allow sharing exported JSON and PDF files
- add new buttons in the UI for sharing
- document sharing capability in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685adc05682c832989d06cb132780ea1