### PR TITLE
Remove share JSON and export PDF buttons

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -15,7 +15,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const importFile = document.getElementById('import-file');
   const clearBtn = document.getElementById('clear-data');
   const exportJsonBtn = document.getElementById('export-json');
-  const exportPdfBtn = document.getElementById('export-pdf');
   const savingOverlay = document.getElementById('saving-overlay');
   const visitCount = document.getElementById('visit-count');
 
@@ -287,7 +286,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const visits = JSON.parse(localStorage.getItem('visits') || '[]');
     const hasData = visits.length > 0;
     exportJsonBtn.disabled = !hasData;
-    exportPdfBtn.disabled = !hasData;
     clearBtn.disabled = !hasData;
     updateVisitCount();
   }
@@ -460,54 +458,6 @@ document.addEventListener('DOMContentLoaded', () => {
       updateButtons();
     }
   });
-
-  if (jsPDF) {
-    document.getElementById('export-pdf').addEventListener('click', () => {
-      const visits = JSON.parse(localStorage.getItem('visits') || '[]');
-      const doc = new jsPDF();
-      const generated = new Date().toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' });
-      visits.forEach((v, idx) => {
-        doc.setFontSize(18);
-        doc.text('Relatório de Visita', 105, 15, { align: 'center' });
-        doc.setFontSize(12);
-        let y = 30;
-        doc.text(`Nome: ${v.clientName}`, 10, y); y += 7;
-        doc.text(`Endereço: ${v.clientAddress}`, 10, y); y += 7;
-        doc.text(`Telefone: ${v.clientPhone}`, 10, y); y += 7;
-        doc.text(`Email: ${v.clientEmail}`, 10, y); y += 7;
-        doc.text(`Data/Hora: ${v.timestamp}`, 10, y); y += 7;
-        if (v.latitude && v.longitude) {
-          doc.text(`Localização: ${v.latitude.toFixed(5)}, ${v.longitude.toFixed(5)}`, 10, y); y += 7;
-        }
-        doc.text(`Dioptria: ${v.diopters}`, 10, y); y += 7;
-        if (v.pupilDistance) {
-          doc.text(`Distância Pupilar: ${v.pupilDistance} mm`, 10, y); y += 7;
-        }
-        if (v.recipeImage) {
-          doc.text('Receita:', 10, y); y += 5;
-          doc.addImage(v.recipeImage, 'JPEG', 10, y, 70, 70);
-          y += 75;
-        }
-        if (Array.isArray(v.catalogImages) && v.catalogImages.length) {
-          doc.text('Catálogo:', 10, y); y += 5;
-          v.catalogImages.forEach(imgUrl => {
-            doc.addImage(imgUrl, 'JPEG', 10, y, 60, 60);
-            y += 65;
-          });
-        }
-        if (v.signature) {
-          doc.text('Assinatura:', 10, y); y += 5;
-          doc.addImage(v.signature, 'PNG', 10, y, 60, 30); y += 35;
-        }
-        doc.setFontSize(10);
-        doc.text(`Gerado por SanOptics em ${generated}`, 105, 285, { align: 'center' });
-        if (idx < visits.length - 1) doc.addPage();
-      });
-      const ts = getBrTimestamp();
-      doc.save(`Visitas_${ts}.pdf`);
-    });
-
-  }
 
   catalogUpload.addEventListener('change', () => {
     const files = Array.from(catalogUpload.files);

--- a/public/index.html
+++ b/public/index.html
@@ -75,8 +75,6 @@
     <section id="history-section">
       <h2 id="history-title">Histórico de Visitas (<span id="visit-count">0</span>)</h2>
       <button id="export-json" disabled>Exportar</button>
-      <button id="share-json" disabled>Compartilhar JSON</button>
-      <button id="export-pdf" disabled>Exportar PDF</button>
       <button id="share-pdf" disabled>Compartilhar PDF</button>
       <button id="import-json">Importar</button>
       <input id="import-file" type="file" accept="application/json" style="display:none">

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SanOptics</title>
   <link rel="stylesheet" href="css/styles.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-YBSKPG8WWG"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-YBSKPG8WWG');
+  </script>
   <script defer src="js/jspdf.umd.min.js"></script>
   <script defer src="js/app.js"></script>
 </head>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -15,8 +15,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const importFile = document.getElementById('import-file');
   const clearBtn = document.getElementById('clear-data');
   const exportJsonBtn = document.getElementById('export-json');
-  const exportPdfBtn = document.getElementById('export-pdf');
-  const shareJsonBtn = document.getElementById('share-json');
   const sharePdfBtn = document.getElementById('share-pdf');
   const savingOverlay = document.getElementById('saving-overlay');
   const visitCount = document.getElementById('visit-count');
@@ -238,7 +236,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-
   function addVisitToHistory(visit, index) {
     const li = document.createElement('li');
     li.dataset.index = index;
@@ -322,8 +319,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const visits = JSON.parse(localStorage.getItem('visits') || '[]');
     const hasData = visits.length > 0;
     exportJsonBtn.disabled = !hasData;
-    shareJsonBtn.disabled = !hasData;
-    exportPdfBtn.disabled = !hasData;
     sharePdfBtn.disabled = !hasData;
     clearBtn.disabled = !hasData;
     updateVisitCount();
@@ -455,16 +450,6 @@ document.addEventListener('DOMContentLoaded', () => {
     download(`Exportado_${ts}.json`, visits);
   });
 
-  if (shareJsonBtn) {
-    shareJsonBtn.addEventListener('click', () => {
-      const visits = localStorage.getItem('visits') || '[]';
-      const ts = getBrTimestamp();
-      const blob = new Blob([visits], { type: 'application/json' });
-      shareFile(`Exportado_${ts}.json`, blob);
-    });
-  }
-
-
   importBtn.addEventListener('click', () => importFile.click());
 
   importFile.addEventListener('change', () => {
@@ -508,51 +493,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   if (jsPDF) {
-    document.getElementById('export-pdf').addEventListener('click', () => {
-      const visits = JSON.parse(localStorage.getItem('visits') || '[]');
-      const doc = new jsPDF();
-      const generated = new Date().toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' });
-      visits.forEach((v, idx) => {
-        doc.setFontSize(18);
-        doc.text('Relatório de Visita', 105, 15, { align: 'center' });
-        doc.setFontSize(12);
-        let y = 30;
-        doc.text(`Nome: ${v.clientName}`, 10, y); y += 7;
-        doc.text(`Endereço: ${v.clientAddress}`, 10, y); y += 7;
-        doc.text(`Telefone: ${v.clientPhone}`, 10, y); y += 7;
-        doc.text(`Email: ${v.clientEmail}`, 10, y); y += 7;
-        doc.text(`Data/Hora: ${v.timestamp}`, 10, y); y += 7;
-        if (v.latitude && v.longitude) {
-          doc.text(`Localização: ${v.latitude.toFixed(5)}, ${v.longitude.toFixed(5)}`, 10, y); y += 7;
-        }
-        doc.text(`Dioptria: ${v.diopters}`, 10, y); y += 7;
-        if (v.pupilDistance) {
-          doc.text(`Distância Pupilar: ${v.pupilDistance} mm`, 10, y); y += 7;
-        }
-        if (v.recipeImage) {
-          doc.text('Receita:', 10, y); y += 5;
-          doc.addImage(v.recipeImage, 'JPEG', 10, y, 70, 70);
-          y += 75;
-        }
-        if (Array.isArray(v.catalogImages) && v.catalogImages.length) {
-          doc.text('Catálogo:', 10, y); y += 5;
-          v.catalogImages.forEach(imgUrl => {
-            doc.addImage(imgUrl, 'JPEG', 10, y, 60, 60);
-            y += 65;
-          });
-        }
-        if (v.signature) {
-          doc.text('Assinatura:', 10, y); y += 5;
-          doc.addImage(v.signature, 'PNG', 10, y, 60, 30); y += 35;
-        }
-        doc.setFontSize(10);
-        doc.text(`Gerado por SanOptics em ${generated}`, 105, 285, { align: 'center' });
-        if (idx < visits.length - 1) doc.addPage();
-      });
-      const ts = getBrTimestamp();
-      doc.save(`Visitas_${ts}.pdf`);
-    });
-
     if (sharePdfBtn) {
       sharePdfBtn.addEventListener('click', () => {
         const visits = JSON.parse(localStorage.getItem('visits') || '[]');


### PR DESCRIPTION
## Summary
- remove `Compartilhar JSON` and `Exportar PDF` buttons from history section
- update JS to drop related functionality

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ae45f71208329beb2c2b8263353a6